### PR TITLE
Group dependabot PRs by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   # Maintain dependencies for Go modules
   - package-ecosystem: "gomod"
@@ -15,3 +19,7 @@ updates:
     schedule:
       # Check for updates to Go modules every weekday
       interval: "monthly"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds grouping to dependabot config so PRs are batched per ecosystem.